### PR TITLE
Fixed routing to own homepage caused by special symbols

### DIFF
--- a/bbs/src/utils/routes.ts
+++ b/bbs/src/utils/routes.ts
@@ -107,7 +107,7 @@ export const pages = {
     withSearchAndHash(
       `/user/${
         params?.username
-          ? `name/${params.username}`
+          ? `name/${encodeURIComponent(params.username)}`
           : params?.uid
             ? params.uid
             : 'me'


### PR DESCRIPTION
修复了“当以name方式访问用户名包含某些特殊字符的用户主页时，会被路由至自己主页”的问题